### PR TITLE
Open Validation Indices file for pickling as binary

### DIFF
--- a/pySetup/splitDatasets.py
+++ b/pySetup/splitDatasets.py
@@ -115,7 +115,7 @@ else:
                 trainingIndices.append(idx)
 
         if writeToFile:
-            with open(validationIndicesFile, 'w') as writeFile:
+            with open(validationIndicesFile, 'wb') as writeFile:
                 # now save that file as a .pkl next to where our test data sits. 
                 pickle.dump(validationIndices, writeFile)
 


### PR DESCRIPTION
Strictly speaking, all pickle files should be opened as binary (reading or writing). This is just to follow that convention, and prepare for Python3 compatibility
